### PR TITLE
(QENG-4648) prevent double api calls for job details, and remove badly named, ine…

### DIFF
--- a/lib/waylon/jenkins/job/rest.rb
+++ b/lib/waylon/jenkins/job/rest.rb
@@ -70,8 +70,7 @@ class Waylon
         end
 
         def description
-          @job_build_details ||= @client.job.get_build_details(@name, last_build_num)
-          @job_build_details['description']
+          @job_build_description ||= @client.job.get_build_details(@name, last_build_num)['description']
         end
 
         # Has this job ever been built?

--- a/lib/waylon/jenkins/job/rest.rb
+++ b/lib/waylon/jenkins/job/rest.rb
@@ -70,14 +70,9 @@ class Waylon
         end
 
         def description
-          @client.job.get_build_details(@name, last_build_num)['description']
+          @job_build_details ||= @client.job.get_build_details(@name, last_build_num)
+          @job_build_details['description']
         end
-
-        def last_build_display_name
-          f = @client.job.get_build_details(@name, last_build_num)['fullDisplayName']
-          return "##{f.split('#')[-1]}"
-        end
-
 
         # Has this job ever been built?
         # @return [Boolean]
@@ -126,7 +121,6 @@ class Waylon
               'last_build_num'          => last_build_num,
               'investigating'           => investigating?,
               'description'             => description,
-              'last_build_display_name' => last_build_display_name,
               'health'                  => health,
             })
           end

--- a/public/js/waylon/view/job.js
+++ b/public/js/waylon/view/job.js
@@ -11,7 +11,7 @@ Waylon.Views.Job = Backbone.View.extend({
                 '<img class="weather"></img>',
             '</div>',
             '<div class="col-md-9 job-details">',
-                '<a href="{{url}}">{{display_name}} {{last_build_display_name}}</a>',
+                '<a href="{{url}}">{{display_name}} #{{last_build_num}}</a>',
             '</div>',
             '<div class="col-md-2 job_action">',
             '</div>',
@@ -68,4 +68,3 @@ Waylon.Views.Job = Backbone.View.extend({
         }
     },
 });
-


### PR DESCRIPTION
…fficient method

The jenkins api was called everytime the description method was called by other methods. Creating an instance variable to hold the details information, and if needed that hash could be re-used if other details are needed.
The method I removed last_build_display_name was also calling the api and passing the build number, and then parsing the full display name to only show what is after the # character, which is the build number. So essentially returning a value we already know. I am not aware of any pipeline dynamically modifying the full display name, so I have removed that and instead referred to the build number directly.