### PR TITLE
Fix weird ordering choices.

### DIFF
--- a/lib/waylon/jenkins/job/memcached.rb
+++ b/lib/waylon/jenkins/job/memcached.rb
@@ -29,6 +29,10 @@ class Waylon
         def description
           @description ||= cache("job-#{name}-description") { super }
         end
+
+        def last_build_timestamp
+          @last_build_timestamp ||= cache("job-#{name}-last-build-timestamp") { super }
+        end
       end
     end
   end

--- a/lib/waylon/jenkins/job/rest.rb
+++ b/lib/waylon/jenkins/job/rest.rb
@@ -91,6 +91,10 @@ class Waylon
           @disabled = job_details['color'] == "disabled"
         end
 
+        def last_build_timestamp
+          @client.job.get_build_details(@name, last_build_num)['timestamp']
+        end
+
         def last_build_num
           job_details['lastBuild']['number']
         end
@@ -123,6 +127,7 @@ class Waylon
 
           if built?
             h.merge!({
+              'last_build_timestamp'    => last_build_timestamp,
               'last_build_num'          => last_build_num,
               'investigating'           => investigating?,
               'description'             => description,

--- a/public/js/waylon/model/job.js
+++ b/public/js/waylon/model/job.js
@@ -74,9 +74,9 @@ Waylon.Models.Job = Backbone.Model.extend({
             return -1;
         } else if (this.priority() < other.priority()) {
             return 1;
-        } else if (this.get('display_name') < other.get('display_name')) {
+        } else if (this.get('last_build_timestamp') > other.get('last_build_timestamp')) {
             return -1;
-        } else if (this.get('display_name') > other.get('display_name')) {
+        } else if (this.get('last_build_timestamp') < other.get('last_build_timestamp')) {
             return 1;
         } else {
             return 0;
@@ -90,18 +90,18 @@ Waylon.Models.Job = Backbone.Model.extend({
             case "aborted":
                 return 90;
             case "disabled":
-                return 70;
+                return 05;
             case "not_run":
-                return 60;
+                return 10;
             case "unknown":
                 return 50;
             case "running":
                 return 80;
             case "success":
-                return 10;
+                return 60;
             default:
                 // Ensure that jobs with an unhandled status are highly visible
-                return 30;
+                return 70;
         }
     },
 });


### PR DESCRIPTION
* "disabled" and "not_run" jobs should be last because chances are no one cares
  about those.
* Within each status category each job should be ordered by last run rather than
  by display name.

This git SHA is already used by waylon-web-prod-1 so we should merge this in and cut a new release