### PR TITLE
(maint) Modify Waylon for development on Windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,11 @@
 source 'https://rubygems.org'
 
 gem 'sinatra',            '~> 1.4.5'
-gem 'unicorn',            '~> 4.8.3'
 gem 'jenkins_api_client', '~> 1.0.1'
 gem 'deterministic',      '~> 0.6.0'
-gem 'memcached',          '~> 1.8.0'
+# These gems will not bundle on Windows platforms
+gem 'unicorn',            '~> 4.8.3', :platform => :ruby
+gem 'memcached',          '~> 1.8.0', :platform => :ruby
 
 group :development do
   gem 'foreman'

--- a/Procfile.windows
+++ b/Procfile.windows
@@ -1,0 +1,1 @@
+web: bundle exec rackup -p $PORT

--- a/README.md
+++ b/README.md
@@ -151,6 +151,30 @@ $ bundle exec foreman start
 ## Development
 See the [CONTRIBUTING](CONTRIBUTING.md) doc.
 
+### Using foreman
+
+For development, running `foreman` will launch the app, with memcached, on Port 5000:
+
+```
+$ bundle exec foreman start --procfile Procfile.development
+10:36:33 web.1      | [2014-05-15 10:36:33] INFO  WEBrick 1.3.1
+10:36:33 memcache.1 | Starting memcached
+10:36:33 web.1      | [2014-05-15 10:36:33] INFO  ruby 2.1.1 (2014-02-24) [x86_64-darwin13.0]
+10:36:33 web.1      | [2014-05-15 10:36:33] INFO  WEBrick::HTTPServer#start: pid=41331 port=9292
+```
+### Using foreman on Windows
+
+For development, running `foreman` will launch the app on Port 5000:
+
+``` powershell
+PS> bundle exec foreman start --procfile Procfile.windows
+10:20:43 web.1  | started with pid 13472
+10:20:46 web.1  | [2017-01-17 10:20:46] INFO  WEBrick 1.3.1
+10:20:46 web.1  | [2017-01-17 10:20:46] INFO  ruby 2.3.0 (2015-12-25) [x64-mingw32]
+10:20:46 web.1  | [2017-01-17 10:20:46] INFO  WEBrick::HTTPServer#start: pid=5148 port=5000
+```
+
+### Using rack
 For development, running `rackup` will launch the app with WEBrick on port 9292:
 
 ```

--- a/config.ru
+++ b/config.ru
@@ -1,2 +1,4 @@
+$stdout.sync=true
+
 require File.join(File.dirname(__FILE__), 'waylon.rb')
 run Waylon.new

--- a/lib/waylon/jenkins/job.rb
+++ b/lib/waylon/jenkins/job.rb
@@ -2,7 +2,7 @@ class Waylon
   module Jenkins
     class Job
       require 'waylon/jenkins/job/rest'
-      require 'waylon/jenkins/job/memcached'
+      require 'waylon/jenkins/job/memcached' unless !!File::ALT_SEPARATOR
 
       attr_reader :name
       attr_reader :server

--- a/lib/waylon/jenkins/server.rb
+++ b/lib/waylon/jenkins/server.rb
@@ -2,7 +2,7 @@ class Waylon
   module Jenkins
     class Server
       require 'waylon/jenkins/server/rest'
-      require 'waylon/jenkins/server/memcached'
+      require 'waylon/jenkins/server/memcached' unless !!File::ALT_SEPARATOR
 
       attr_reader :config
 


### PR DESCRIPTION
Previously, even though ruby is cross platform, Waylon could not be used on a
Windows platform due to the use of the unicorn and memcached gems.  These gems
have native extensions which can not be compiled on Windows.  This commit
modifies Waylon so at least the majority of Waylon development can occur on
Windows:

- Modifies the Gemfile to not include those gems on Windows platforms
- Modifies Waylon to not try to require memcached based classed when on Windows
  platforms
- Adds a Procfile.windows so that foreman can be used to run Waylon on Window
- Updates documentation on how to run foreman on Windows
- Forces STDOUT synchronisation in rack.  Previously the log entries were being
  swallowed until the app quit (flushed the STDOUT buffer).  The log output from
  Waylon is small enough so this will not cause an issue