### PR TITLE
(maint) Add nicer timestamps in view

### DIFF
--- a/lib/waylon/jenkins/job/rest.rb
+++ b/lib/waylon/jenkins/job/rest.rb
@@ -56,9 +56,8 @@ class Waylon
           # after it has completed. Using estimatedDuration and the
           # executor progress (in percentage), we can calculate the ETA.
           if progress_pct != -1 then
-            t      = (est_duration - (est_duration * (progress_pct / 100.0)))
-            mm, ss = t.divmod(60)
-            return "#{mm}m #{ss.floor}s"
+            t = (est_duration - (est_duration * (progress_pct / 100.0)))
+            pretty_timespan(t,false)
           else
             'unknown'
           end
@@ -86,7 +85,12 @@ class Waylon
         end
 
         def last_build_timestamp
-          @client.job.get_build_details(@name, last_build_num)['timestamp']
+          @last_build_timestamp ||= @client.job.get_build_details(@name, last_build_num)['timestamp']
+        end
+
+        def since_last_build
+          # Figure out the number of seconds between the last_build_timestamp and now.
+          pretty_timespan(Time.now.to_i - Time.at(last_build_timestamp / 1000).to_i ,true)
         end
 
         def last_build_num
@@ -122,6 +126,7 @@ class Waylon
           if built?
             h.merge!({
               'last_build_timestamp'    => last_build_timestamp,
+              'since_last_build'        => since_last_build,
               'last_build_num'          => last_build_num,
               'investigating'           => investigating?,
               'description'             => description,
@@ -131,8 +136,9 @@ class Waylon
 
           if status == 'running'
             h.merge!({
-              'progress_pct' => progress_pct,
-              'eta'          => eta,
+              'progress_pct'     => progress_pct,
+              'eta'              => eta,
+              'since_last_build' => nil,
             })
           else
             h.merge!({
@@ -156,6 +162,25 @@ class Waylon
         end
 
         private
+
+        # Returns a timespan, expressed as the number of seconds elapsed as pretty string
+        #  Optionally ignore the seconds in the string
+        #  e.g.  2d 6h 45m 28s
+        # @return [String]
+        def pretty_timespan(timespan, ignore_seconds = false)
+          dd, hh, mm, ss = [timespan/86400, timespan/3600%24, timespan/60%60, timespan%60].map! { |x| x.floor }
+          pretty = ''
+          if dd > 0
+            pretty = "#{dd}d #{hh}h #{mm}m"
+          elsif hh > 0
+            pretty = "#{hh}h #{mm}m"
+          else
+            pretty = "#{mm}m"
+          end
+          pretty =+ " #{ss}s" unless ignore_seconds
+          
+          pretty.strip
+        end
 
         def query!
           # per cloudbees best practices we should never query the API/json base URL but rather use the tree parameter

--- a/public/js/waylon/view/job.js
+++ b/public/js/waylon/view/job.js
@@ -11,7 +11,7 @@ Waylon.Views.Job = Backbone.View.extend({
                 '<img class="weather"></img>',
             '</div>',
             '<div class="col-md-9 job-details">',
-                '<a href="{{url}}">{{display_name}} #{{last_build_num}}</a>',
+                '<a href="{{url}}">{{display_name}} #{{last_build_num}}</a>{{# if since_last_build}} - {{since_last_build}} ago{{/if}}',
             '</div>',
             '<div class="col-md-2 job_action">',
             '</div>',


### PR DESCRIPTION
Previously the timestamps displayed on minutes and seconds, whereas hours was
also important.  Also there was no information on when the last build was
finished.  This commit modifies the timespan tet converter so that it displays
days, hours, minutes and seconds as appropriate.  Also it does not show units
which are not required e.g. `0d 0h 0m 12s` shows only as `12s` because the other
units are all zero.

This commit also adds a `since_last_build` value to the job api, which is the
amount of time since the last job was started (derived form last_build_timestamp).