### PR TITLE
(QENG-4648) Third pass to address inefficient api queries

### DIFF
--- a/lib/waylon/jenkins/job/rest.rb
+++ b/lib/waylon/jenkins/job/rest.rb
@@ -16,6 +16,10 @@ class Waylon
           @job_details ||= query!
         end
 
+        def job_build_details
+          @job_build_details ||= query_build!
+        end
+
         def status
           if disabled?
             "disabled"
@@ -70,7 +74,7 @@ class Waylon
         end
 
         def description
-          @job_build_description ||= @client.job.get_build_details(@name, last_build_num)['description']
+          @job_build_description ||= job_build_details['description']
         end
 
         # Has this job ever been built?
@@ -86,7 +90,7 @@ class Waylon
         end
 
         def last_build_timestamp
-          @client.job.get_build_details(@name, last_build_num)['timestamp']
+          @last_build_timestamp ||= job_build_details['timestamp']
         end
 
         def last_build_num
@@ -161,6 +165,14 @@ class Waylon
           # per cloudbees best practices we should never query the API/json base URL but rather use the tree parameter
           # https://www.cloudbees.com/blog/taming-jenkins-json-api-depth-and-tree
           client.api_get_request("/job/#{URI.escape @name}","tree=displayName,color,firstBuild,lastBuild[number],healthReport[*],url")
+        rescue JenkinsApi::Exceptions::NotFound
+          raise Waylon::Errors::NotFound
+        end
+
+        def query_build!
+          # per cloudbees best practices we should never query the API/json base URL but rather use the tree parameter
+          # https://www.cloudbees.com/blog/taming-jenkins-json-api-depth-and-tree
+          client.api_get_request("/job/#{URI.escape @name}/#{last_build_num}","tree=description,timestamp")
         rescue JenkinsApi::Exceptions::NotFound
           raise Waylon::Errors::NotFound
         end

--- a/lib/waylon/jenkins/job/rest.rb
+++ b/lib/waylon/jenkins/job/rest.rb
@@ -73,7 +73,7 @@ class Waylon
         end
 
         def description
-          return nil unless job_build_details['description']
+          return nil unless job_build_details
           @job_build_description ||= job_build_details['description']
         end
 
@@ -90,7 +90,7 @@ class Waylon
         end
 
         def last_build_timestamp
-          return nil unless job_build_details['timestamp']
+          return nil unless job_build_details
           @last_build_timestamp ||= job_build_details['timestamp']
         end
 


### PR DESCRIPTION
the job detail for specific build was still requesting the base api/json
as per the ruby module's jenkins_api_client implementation of querying
job details. Replaced with a custom query using the tree parameter for
description and timestamp