### PR TITLE
(QENG-4783) Reverse increment operator

### DIFF
--- a/lib/waylon/jenkins/job/rest.rb
+++ b/lib/waylon/jenkins/job/rest.rb
@@ -183,7 +183,7 @@ class Waylon
           else
             pretty = "#{mm}m"
           end
-          pretty =+ " #{ss}s" unless ignore_seconds
+          pretty += " #{ss}s" unless ignore_seconds
 
           pretty.strip
         end


### PR DESCRIPTION
Waylon was generating HTTP 500 errors:

    undefined method `+@' for " 18s":String:

Because `=+` is not a valid ruby operator. Flip it to `+=` so things work.